### PR TITLE
Use forme for form generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Ignore locally generated content
 public/images/generated/*.bmp
+db/*.sqlite3

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Ignore locally generated content
 public/images/generated/*.bmp
 db/*.sqlite3
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,5 @@ RUN bundle exec rake db:setup
 # Expose the port that the application will run on
 EXPOSE 4567
 
-ENV APP_ENV=production
-
 # Command to run the application
 CMD ["bundle", "exec", "ruby", "app.rb", "-o", "0.0.0.0"]

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,11 @@ gem 'activerecord'
 gem 'json'
 gem 'rake'
 gem 'sinatra-activerecord'
+gem 'puma'
+gem 'rackup'
+gem 'forme'
+gem 'pry'
+gem 'dotenv', groups: [:development, :test]
 
 # browser automation
 gem 'ferrum', git: 'https://github.com/rubycdp/ferrum.git', ref: '7cc1a63351232b10f9ce191104efe6e9c72acca2'
@@ -24,10 +29,3 @@ end
 group :development, :test do
   gem 'debug'
 end
-
-
-gem "puma", "~> 6.5"
-
-gem "rackup", "~> 2.2"
-
-gem "forme", "~> 2.6"

--- a/Gemfile
+++ b/Gemfile
@@ -25,3 +25,7 @@ group :development, :test do
   gem 'debug'
 end
 
+
+gem "puma", "~> 6.5"
+
+gem "rackup", "~> 2.2"

--- a/Gemfile
+++ b/Gemfile
@@ -29,3 +29,5 @@ end
 gem "puma", "~> 6.5"
 
 gem "rackup", "~> 2.2"
+
+gem "forme", "~> 2.6"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,12 +37,14 @@ GEM
     base64 (0.2.0)
     benchmark (0.4.0)
     bigdecimal (3.1.8)
+    coderay (1.1.3)
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
     date (3.4.1)
     debug (1.9.2)
       irb (~> 1.10)
       reline (>= 0.3.8)
+    dotenv (3.1.7)
     drb (2.2.1)
     forme (2.6.0)
       bigdecimal
@@ -54,6 +56,7 @@ GEM
       reline (>= 0.4.2)
     json (2.9.0)
     logger (1.6.5)
+    method_source (1.1.0)
     mime-types (3.6.0)
       logger
       mime-types-data (~> 3.2015)
@@ -64,6 +67,9 @@ GEM
     mustermann (3.0.3)
       ruby2_keywords (~> 0.0.1)
     nio4r (2.7.4)
+    pry (0.15.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     psych (5.2.1)
       date
       stringio
@@ -122,13 +128,15 @@ PLATFORMS
 DEPENDENCIES
   activerecord
   debug
+  dotenv
   ferrum!
-  forme (~> 2.6)
+  forme
   json
   mini_magick (~> 4.12.0)
-  puma (~> 6.5)
+  pry
+  puma
   puppeteer-ruby (~> 0.45.6)
-  rackup (~> 2.2)
+  rackup
   rake
   sinatra-activerecord
   sqlite3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,14 +57,17 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2024.1203)
     mini_magick (4.12.0)
+    mini_portile2 (2.8.8)
     minitest (5.25.4)
     mustermann (3.0.3)
       ruby2_keywords (~> 0.0.1)
-    pg (1.5.9)
+    nio4r (2.7.4)
     psych (5.2.1)
       date
       stringio
     public_suffix (6.0.1)
+    puma (6.5.0)
+      nio4r (~> 2.0)
     puppeteer-ruby (0.45.6)
       concurrent-ruby (>= 1.1, < 1.4)
       mime-types (>= 3.0)
@@ -77,6 +80,8 @@ GEM
     rack-session (2.1.0)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
+    rackup (2.2.1)
+      rack (>= 3)
     rake (13.2.1)
     rdoc (6.8.1)
       psych (>= 4.0.0)
@@ -94,6 +99,9 @@ GEM
     sinatra-activerecord (2.0.28)
       activerecord (>= 4.1)
       sinatra (>= 1.0)
+    sqlite3 (2.5.0)
+      mini_portile2 (~> 2.8.0)
+    sqlite3 (2.5.0-x86_64-darwin)
     stringio (3.1.2)
     tilt (2.6.0)
     timeout (0.4.2)
@@ -115,10 +123,12 @@ DEPENDENCIES
   ferrum!
   json
   mini_magick (~> 4.12.0)
-  pg
+  puma (~> 6.5)
   puppeteer-ruby (~> 0.45.6)
+  rackup (~> 2.2)
   rake
   sinatra-activerecord
+  sqlite3
 
 BUNDLED WITH
    2.5.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,8 @@ GEM
       irb (~> 1.10)
       reline (>= 0.3.8)
     drb (2.2.1)
+    forme (2.6.0)
+      bigdecimal
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
     io-console (0.8.0)
@@ -121,6 +123,7 @@ DEPENDENCIES
   activerecord
   debug
   ferrum!
+  forme (~> 2.6)
   json
   mini_magick (~> 4.12.0)
   puma (~> 6.5)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # TRMNL BYOS - Ruby/Sinatra
+
 with this project you can point a TRMNL (https://usetrmnl.com) device to your own server, either in the cloud or on your local network.
 
 **requirements**
@@ -17,6 +18,7 @@ ruby app.rb # => runs server, visit http://localhost:4567
 
 **docker-based setup**
 You may optionally edit the Dockerfile to enable sqlite.
+
 ```
 docker build -t trmnl_byos -f Dockerfile .
 docker run --name trmnl -p 4567:4567 trmnl_byos
@@ -39,8 +41,7 @@ on your local network:
 1. run app in production mode (`ruby app.rb`)
 2. retrieve your machine's local IP, ex 192.168.x.x (Mac: `ifconfig | grep "inet " | grep -Fv 127.0.0.1 | awk '{print $2}'`)
 3. confirm it works by visiting `http://192.168.x.x:4567/devices` from any device also on the network
-4. set `BASE_URL` inside `app.rb` to this domain (`http://192.168.x.x:4567`, no trailing slash)
-4. point your [forked FW's](https://github.com/usetrmnl/firmware) `API_BASE_URL` ([source](https://github.com/usetrmnl/firmware/blob/2ee0723c66a3468b969c83d7663ffb3f8322ad99/include/config.h#L56)) to same value as `BASE_URL`
+4. point your [forked FW's](https://github.com/usetrmnl/firmware) `API_BASE_URL` ([source](https://github.com/usetrmnl/firmware/blob/2ee0723c66a3468b969c83d7663ffb3f8322ad99/include/config.h#L56)) to where your server is running
 
 in the cloud:
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # TRMNL BYOS - Ruby/Sinatra
-
 with this project you can point a TRMNL (https://usetrmnl.com) device to your own server, either in the cloud or on your local network.
 
 **requirements**
@@ -18,7 +17,6 @@ ruby app.rb # => runs server, visit http://localhost:4567
 
 **docker-based setup**
 You may optionally edit the Dockerfile to enable sqlite.
-
 ```
 docker build -t trmnl_byos -f Dockerfile .
 docker run --name trmnl -p 4567:4567 trmnl_byos
@@ -41,7 +39,8 @@ on your local network:
 1. run app in production mode (`ruby app.rb`)
 2. retrieve your machine's local IP, ex 192.168.x.x (Mac: `ifconfig | grep "inet " | grep -Fv 127.0.0.1 | awk '{print $2}'`)
 3. confirm it works by visiting `http://192.168.x.x:4567/devices` from any device also on the network
-4. point your [forked FW's](https://github.com/usetrmnl/firmware) `API_BASE_URL` ([source](https://github.com/usetrmnl/firmware/blob/2ee0723c66a3468b969c83d7663ffb3f8322ad99/include/config.h#L56)) to where your server is running
+4. set `BASE_URL` inside `app.rb` to this domain (`http://192.168.x.x:4567`, no trailing slash)
+4. point your [forked FW's](https://github.com/usetrmnl/firmware) `API_BASE_URL` ([source](https://github.com/usetrmnl/firmware/blob/2ee0723c66a3468b969c83d7663ffb3f8322ad99/include/config.h#L56)) to same value as `BASE_URL`
 
 in the cloud:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # TRMNL BYOS - Ruby/Sinatra
+
 with this project you can point a TRMNL (https://usetrmnl.com) device to your own server, either in the cloud or on your local network.
 
 **requirements**
@@ -10,6 +11,7 @@ with this project you can point a TRMNL (https://usetrmnl.com) device to your ow
 **quickstart**
 
 ```
+cp dotenv-sample .env (and edit to set the appropriate variables)
 bundle # installs gems/libs
 rake db:setup # creates db + Devices table
 ruby app.rb # => runs server, visit http://localhost:4567
@@ -17,7 +19,9 @@ ruby app.rb # => runs server, visit http://localhost:4567
 
 **docker-based setup**
 You may optionally edit the Dockerfile to enable sqlite.
+
 ```
+cp dotenv-sample .env (and edit to set the appropriate variables)
 docker build -t trmnl_byos -f Dockerfile .
 docker run --name trmnl -p 4567:4567 trmnl_byos
 ```
@@ -36,11 +40,11 @@ ScreenGenerator.new("<p>Some HTML here</p>").process # => creates img in /public
 
 on your local network:
 
-1. run app in production mode (`ruby app.rb`)
-2. retrieve your machine's local IP, ex 192.168.x.x (Mac: `ifconfig | grep "inet " | grep -Fv 127.0.0.1 | awk '{print $2}'`)
-3. confirm it works by visiting `http://192.168.x.x:4567/devices` from any device also on the network
-4. set `BASE_URL` inside `app.rb` to this domain (`http://192.168.x.x:4567`, no trailing slash)
-4. point your [forked FW's](https://github.com/usetrmnl/firmware) `API_BASE_URL` ([source](https://github.com/usetrmnl/firmware/blob/2ee0723c66a3468b969c83d7663ffb3f8322ad99/include/config.h#L56)) to same value as `BASE_URL`
+1. set `BASE_URL` inside the file `.env` to where this is hosted (eg `http://192.168.x.x:4567`, no trailing slash)
+2. run app in production mode (`ruby app.rb`)
+3. retrieve your machine's local IP, ex 192.168.x.x (Mac: `ifconfig | grep "inet " | grep -Fv 127.0.0.1 | awk '{print $2}'`)
+4. confirm it works by visiting `http://192.168.x.x:4567/devices` from any device also on the network
+5. point your [forked FW's](https://github.com/usetrmnl/firmware) `API_BASE_URL` ([source](https://github.com/usetrmnl/firmware/blob/2ee0723c66a3468b969c83d7663ffb3f8322ad99/include/config.h#L56)) to same value as `BASE_URL`
 
 in the cloud:
 

--- a/app.rb
+++ b/app.rb
@@ -1,5 +1,6 @@
 require 'sinatra'
 require 'sinatra/activerecord'
+require 'dotenv/load'
 require 'debug'
 
 require_relative 'config/initializers/tailwind_form'
@@ -8,8 +9,7 @@ require_relative 'config/initializers/explicit_forme_plugin'
 # allows access on a local network at 192.168.x.x:4567; remove to scope to localhost:4567
 set :bind, '0.0.0.0'
 
-# set to your local network (or prod domain)
-BASE_URL = 'http://192.168.68.57:4567'
+BASE_URL = ENV['BASE_URL']
 
 current_dir = Dir.pwd
 Dir["#{current_dir}/models/*.rb"].each { |file| require file } # require models

--- a/app.rb
+++ b/app.rb
@@ -8,26 +8,14 @@ require_relative 'config/initializers/explicit_forme_plugin'
 # allows access on a local network at 192.168.x.x:4567; remove to scope to localhost:4567
 set :bind, '0.0.0.0'
 
+# set to your local network (or prod domain)
+BASE_URL = 'http://192.168.68.57:4567'
+
 current_dir = Dir.pwd
 Dir["#{current_dir}/models/*.rb"].each { |file| require file } # require models
 Dir["#{current_dir}/services/*.rb"].each { |file| require file } # require services
 
 helpers do
-  def url_for(path = '', options = {})
-    scheme = options[:scheme] || request.scheme
-    host = options[:host] || request.host
-    port = options[:port] || request.port
-
-    base = "#{scheme}://#{host}"
-    if scheme == "http"
-      base += ":#{port}" unless port == 80
-    elsif scheme == "https"
-      base += ":#{port}" unless port == 443
-    end
-
-    URI.join(base, path).to_s
-  end
-
   def create_forme(model, is_edit, attrs={}, options={})
     attrs[:method] = :post
     options = TailwindConfig.options.merge(options)
@@ -103,7 +91,7 @@ get '/api/setup/' do
     status = 200
     api_key = @device.api_key
     friendly_id = @device.friendly_id
-    image_url = url_for("/images/setup/setup-logo.bmp")
+    image_url = "#{BASE_URL}/images/setup/setup-logo.bmp"
     message = "Welcome to TRMNL BYOS"
 
     { status:, api_key:, friendly_id:, image_url:, message: }.to_json
@@ -116,7 +104,7 @@ end
 get '/api/display/' do
   content_type :json
   @device = Device.find_by_api_key(env['HTTP_ACCESS_TOKEN'])
-  screen = ScreenFetcher.call(self)
+  screen = ScreenFetcher.call
 
   if @device
     {

--- a/config/initializers/explicit_forme_plugin.rb
+++ b/config/initializers/explicit_forme_plugin.rb
@@ -1,0 +1,28 @@
+module ExplicitFormePlugin
+  attr_reader :_form_tag
+
+  def form_tag(attrs)
+    @_form_tag = ::Forme::Tag.new(self, :form, attrs)
+  end
+
+  def explicit_open()
+    @to_s << self.serialize_open(@_form_tag)
+    self.before_form_yield
+    @to_s
+  end
+
+  def explicit_close()
+    form_len = @to_s.length
+    self.after_form_yield
+    @to_s << self.serialize_close(@_form_tag)
+    @to_s[form_len..]
+  end
+  
+  def form_output(&block)
+    form_str = String.new
+    form_str << self.explicit_open()
+    form_str << block.call if block_given?
+    form_str << self.explicit_close()
+    form_str
+  end
+end

--- a/config/initializers/tailwind_form.rb
+++ b/config/initializers/tailwind_form.rb
@@ -1,0 +1,63 @@
+require 'forme'
+require 'pp'
+
+module TailwindConfig
+  def self.label_attr 
+    { 
+      class: 'block text-gray-700 text-md leading-4 font-medium mb-2' 
+    }
+  end
+
+  def self.before 
+    -> (form) {
+      form.to_s << '<div class="rounded-xl bg-gray-50 shadow-sm border mb-6 divide-y divide-gray-200">'
+    }
+  end
+
+  def self.after 
+    -> (form) {
+      form.to_s << '</div>'
+    }
+  end
+
+  def self.options
+    {
+      labeler: :explicit,
+      wrapper: :div,
+      before: self.before,
+      after: self.after,
+      input_defaults: {
+        text: {
+          label_attr: self.label_attr,
+          wrapper_attr: { class: 'p-6' },
+          class: 'block mt-2 min-h-12 px-4 rounded-xl text-black bg-white block w-full p-0 outline-none text-sm border border-gray-300 focus:outline-none ring-2 ring-transparent focus:ring-2 ring-offset-gray-200 focus:ring-offset-2 focus:ring-offset-gray-200 focus:ring-blue-500 focus:border-transparent transition duration-150' ,
+        },
+
+        number: {
+          label_attr: self.label_attr,
+          wrapper_attr: { class: 'p-6' },
+          class: 'block mt-2 min-h-12 px-4 rounded-xl text-black bg-white block w-full p-0 outline-none text-sm border border-gray-300 focus:outline-none ring-2 ring-transparent focus:ring-2 ring-offset-gray-200 focus:ring-offset-2 focus:ring-offset-gray-200 focus:ring-blue-500 focus:border-transparent transition duration-150' ,
+        },
+
+        time: {
+          label_attr: self.label_attr,
+          wrapper_attr: { class: 'p-6' },
+          class: 'block mt-2 min-h-12 px-4 rounded-xl text-black bg-white block w-full p-0 outline-none text-sm border border-gray-300 focus:outline-none ring-2 ring-transparent focus:ring-2 ring-offset-gray-200 focus:ring-offset-2 focus:ring-offset-gray-200 focus:ring-blue-500 focus:border-transparent transition duration-150' ,
+        },
+
+        checkbox: {
+          label_position: :before,
+          label_attr: self.label_attr,
+          wrapper_attr: { class: 'p-6' },
+          class: 'h-8 w-8 rounded-full shadow',
+        },
+
+        submit: {
+          label_attr: self.label_attr,
+          attr: { class: 'cursor-pointer font-medium rounded-lg text-sm px-3 py-2 inline-flex items-center transition duration-150 justify-center shrink-0 gap-1.5 whitespace-nowrap text-white bg-blue-500 hover:bg-blue-600 focus:outline-none' },
+          wrapper_attr: { class: 'p-6 text-right' },
+        },
+      },
+    }
+  end
+end

--- a/dotenv-sample
+++ b/dotenv-sample
@@ -1,0 +1,2 @@
+BASE_URL="http://192.168.68.57:4567"
+APP_ENV="production"

--- a/services/screen_fetcher.rb
+++ b/services/screen_fetcher.rb
@@ -1,22 +1,25 @@
 class ScreenFetcher
   class << self
-    def call(app)
-      last_generated_image(app) || empty_state_image(app)
+    def call
+      last_generated_image || empty_state_image
     end
 
-    def last_generated_image(app)
+    def last_generated_image
       img_path = Dir.glob(File.join(base_path, '*.*')).max { |a, b| File.ctime(a) <=> File.ctime(b) }
       return nil unless img_path
 
       filename = img_path.split('/').last # => 1as4ff.bmp
-      image_url = app.url_for("/images/generated/#{filename}")
+      image_url = "#{base_domain}/images/generated/#{filename}"
 
       { filename:, image_url: }
     end
 
-    def empty_state_image(app)
-      image_url =  app.url_for("/images/setup/setup-logo.bmp")
-      { filename: 'empty_state', image_url: image_url }
+    def base_domain
+      BASE_URL
+    end
+
+    def empty_state_image
+      { filename: 'empty_state', image_url: "#{base_domain}/images/setup/setup-logo.bmp" }
     end
 
     def base_path

--- a/services/screen_fetcher.rb
+++ b/services/screen_fetcher.rb
@@ -1,25 +1,22 @@
 class ScreenFetcher
   class << self
-    def call
-      last_generated_image || empty_state_image
+    def call(app)
+      last_generated_image(app) || empty_state_image(app)
     end
 
-    def last_generated_image
+    def last_generated_image(app)
       img_path = Dir.glob(File.join(base_path, '*.*')).max { |a, b| File.ctime(a) <=> File.ctime(b) }
       return nil unless img_path
 
       filename = img_path.split('/').last # => 1as4ff.bmp
-      image_url = "#{base_domain}/images/generated/#{filename}"
+      image_url = app.url_for("/images/generated/#{filename}")
 
       { filename:, image_url: }
     end
 
-    def base_domain
-      BASE_URL
-    end
-
-    def empty_state_image
-      { filename: 'empty_state', image_url: "#{base_domain}/images/setup/setup-logo.bmp" }
+    def empty_state_image(app)
+      image_url =  app.url_for("/images/setup/setup-logo.bmp")
+      { filename: 'empty_state', image_url: image_url }
     end
 
     def base_path

--- a/views/devices/edit.erb
+++ b/views/devices/edit.erb
@@ -1,2 +1,8 @@
 <%= erb :"shared/heading", locals: { title: "Edit '#{@device.name}'" } %>
-<%= erb :"devices/form", locals: { device: @device } %>
+<%= create_forme(@device, @device.persisted?, 
+        {autocomplete:"off", action: "/devices"},
+        {namespace: "device"}
+        ) do |form|  
+        erb :"devices/form", locals: { f: form, device: @device } 
+    end
+%>

--- a/views/devices/edit.erb
+++ b/views/devices/edit.erb
@@ -1,8 +1,4 @@
 <%= erb :"shared/heading", locals: { title: "Edit '#{@device.name}'" } %>
-<%= create_forme(@device, @device.persisted?, 
-        {autocomplete:"off", action: "/devices"},
-        {namespace: "device"}
-        ) do |form|  
-        erb :"devices/form", locals: { f: form, device: @device } 
-    end
-%>
+<%= @form.form_output() do 
+    erb :"devices/form"
+end %>

--- a/views/devices/form.erb
+++ b/views/devices/form.erb
@@ -1,9 +1,8 @@
-<%= f.input :name, label: "Name", placeholder: "My TRMNL" %>
-<%= f.input :mac_address, label: "MAC Address", placeholder: "xx:xx:xx:xx:xx:xx" %>
-<% if device.persisted? %>
-  <%= f.input :refresh_interval, label: "Refresh Interval", placeholder: "15" %>
-  <%= f.input :friendly_id, label: "Friendly ID", placeholder: "office_desk" %>
-  <%= f.input :api_key, label: "API Key", placeholder: "xxxxxxxxxx" %>
+<%= @form.input :name, label: "Name", placeholder: "My TRMNL" %>
+<%= @form.input :mac_address, label: "MAC Address", placeholder: "xx:xx:xx:xx:xx:xx" %>
+<% if @device.persisted? %>
+  <%= @form.input :refresh_interval, label: "Refresh Interval", placeholder: "15" %>
+  <%= @form.input :friendly_id, label: "Friendly ID", placeholder: "office_desk" %>
+  <%= @form.input :api_key, label: "API Key", placeholder: "xxxxxxxxxx" %>
 <% end %>
-<%= f.button 'Save' %>
-<input type="text" required="true" name="device[mac_address]" id="device_mac_address" value="" class="block mt-2 min-h-12 px-4 rounded-xl text-black bg-white block w-full p-0 outline-none text-sm border border-gray-300 focus:outline-none ring-2 ring-transparent focus:ring-2 ring-offset-gray-200 focus:ring-offset-2 focus:ring-offset-gray-200 focus:ring-blue-500 focus:border-transparent transition duration-150" placeholder="XX:XX:XX:XX:XX">
+<%= @form.button 'Save' %>

--- a/views/devices/form.erb
+++ b/views/devices/form.erb
@@ -1,36 +1,9 @@
-<form autocomplete="off" action="/devices<%= "/#{device.id}" if device.persisted? %>" accept-charset="UTF-8" method="post">
-
-  <% if device.persisted? %>
-    <input name="_method" value="patch" type="hidden"/>
-  <% end %>
-
-  <div class="rounded-xl bg-gray-50 shadow-sm border mb-6 divide-y divide-gray-200">
-    <div class="p-6">
-      <label for="device_name" class="block text-gray-700 text-md leading-4 font-medium mb-2">Name</label>
-      <input type="text" required="true" name="device[name]" id="device_name" value="<%= device.name %>" class="block mt-2 min-h-12 px-4 rounded-xl text-black bg-white block w-full p-0 outline-none text-sm border border-gray-300 focus:outline-none ring-2 ring-transparent focus:ring-2 ring-offset-gray-200 focus:ring-offset-2 focus:ring-offset-gray-200 focus:ring-blue-500 focus:border-transparent transition duration-150" placeholder="My TRMNL">
-    </div>
-    <div class="p-6">
-      <label for="device_mac_address" class="block text-gray-700 text-md leading-4 font-medium mb-2">Mac Address</label>
-      <input type="text" required="true" name="device[mac_address]" id="device_mac_address" value="<%= device.mac_address %>" class="block mt-2 min-h-12 px-4 rounded-xl text-black bg-white block w-full p-0 outline-none text-sm border border-gray-300 focus:outline-none ring-2 ring-transparent focus:ring-2 ring-offset-gray-200 focus:ring-offset-2 focus:ring-offset-gray-200 focus:ring-blue-500 focus:border-transparent transition duration-150" placeholder="XX:XX:XX:XX:XX">
-    </div>
-
-    <% if device.persisted? %>
-      <div class="p-6">
-        <label for="device_refresh_interval" class="block text-gray-700 text-md leading-4 font-medium mb-2">Refresh Interval</label>
-        <input type="text" required="true" name="device[refresh_interval]" id="device_refresh_interval" value="<%= device.refresh_interval %>" class="block mt-2 min-h-12 px-4 rounded-xl text-black bg-white block w-full p-0 outline-none text-sm border border-gray-300 focus:outline-none ring-2 ring-transparent focus:ring-2 ring-offset-gray-200 focus:ring-offset-2 focus:ring-offset-gray-200 focus:ring-blue-500 focus:border-transparent transition duration-150" placeholder="qwerty_asdf_420">
-      </div>
-      <div class="p-6">
-        <label for="device_friendly_id" class="block text-gray-700 text-md leading-4 font-medium mb-2">Friendly ID</label>
-        <input type="text" required="true" name="device[friendly_id]" id="device_friendly_id" value="<%= device.friendly_id %>" class="block mt-2 min-h-12 px-4 rounded-xl text-black bg-white block w-full p-0 outline-none text-sm border border-gray-300 focus:outline-none ring-2 ring-transparent focus:ring-2 ring-offset-gray-200 focus:ring-offset-2 focus:ring-offset-gray-200 focus:ring-blue-500 focus:border-transparent transition duration-150" placeholder="qwerty_asdf_420">
-      </div>
-      <div class="p-6">
-        <label for="device_api_key" class="block text-gray-700 text-md leading-4 font-medium mb-2">API Key</label>
-        <input type="text" required="true" name="device[api_key]" id="device_api_key" value="<%= device.api_key %>" class="block mt-2 min-h-12 px-4 rounded-xl text-black bg-white block w-full p-0 outline-none text-sm border border-gray-300 focus:outline-none ring-2 ring-transparent focus:ring-2 ring-offset-gray-200 focus:ring-offset-2 focus:ring-offset-gray-200 focus:ring-blue-500 focus:border-transparent transition duration-150" placeholder="qwerty_asdf_420">
-      </div>
-    <% end %>
-
-    <div class="p-6 text-right">
-      <input type="submit" name="commit" value="Save" class="cursor-pointer font-medium rounded-lg text-sm px-3 py-2 inline-flex items-center transition duration-150 justify-center shrink-0 gap-1.5 whitespace-nowrap text-white bg-blue-500 hover:bg-blue-600 focus:outline-none">
-    </div>
-  </div>
-</form>
+<%= f.input :name, label: "Name", placeholder: "My TRMNL" %>
+<%= f.input :mac_address, label: "MAC Address", placeholder: "xx:xx:xx:xx:xx:xx" %>
+<% if device.persisted? %>
+  <%= f.input :refresh_interval, label: "Refresh Interval", placeholder: "15" %>
+  <%= f.input :friendly_id, label: "Friendly ID", placeholder: "office_desk" %>
+  <%= f.input :api_key, label: "API Key", placeholder: "xxxxxxxxxx" %>
+<% end %>
+<%= f.button 'Save' %>
+<input type="text" required="true" name="device[mac_address]" id="device_mac_address" value="" class="block mt-2 min-h-12 px-4 rounded-xl text-black bg-white block w-full p-0 outline-none text-sm border border-gray-300 focus:outline-none ring-2 ring-transparent focus:ring-2 ring-offset-gray-200 focus:ring-offset-2 focus:ring-offset-gray-200 focus:ring-blue-500 focus:border-transparent transition duration-150" placeholder="XX:XX:XX:XX:XX">

--- a/views/devices/new.erb
+++ b/views/devices/new.erb
@@ -1,2 +1,8 @@
 <%= erb :"shared/heading", locals: { title: 'Register a device' } %>
-<%= erb :"devices/form", locals: { device: @device } %>
+<%= create_forme(@device, @device.persisted?, 
+        {autocomplete:"off", action: "/devices"},
+        {namespace: "device"}
+        ) do |form|  
+        erb :"devices/form", locals: { f: form, device: @device } 
+    end
+%>

--- a/views/devices/new.erb
+++ b/views/devices/new.erb
@@ -1,8 +1,4 @@
-<%= erb :"shared/heading", locals: { title: 'Register a device' } %>
-<%= create_forme(@device, @device.persisted?, 
-        {autocomplete:"off", action: "/devices"},
-        {namespace: "device"}
-        ) do |form|  
-        erb :"devices/form", locals: { f: form, device: @device } 
-    end
-%>
+<%= erb :"shared/heading", locals: { title: "Register a device" } %>
+<%= @form.form_output() do 
+    erb :"devices/form"
+end %>


### PR DESCRIPTION
Adds the forme library to generate forms, with the same tailwind styling.
Use sinatra's base info to generate URLs without the need to set a BASE_URL manually.
Add missing packages for running Sinatra in Docker.