### PR TITLE
doc: set export BYOS_DATABASE=sqlite before bundle install

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ with this project you can point a TRMNL (https://usetrmnl.com) device to your ow
 
 ```
 cp dotenv-sample .env # (and edit to set the appropriate variables)
+export BYOS_DATABASE=sqlite # or 'pg' for postgres
 bundle # installs gems/libs
 rake db:setup # creates db + Devices table
 ruby app.rb # runs server, visit http://localhost:4567/devices/new


### PR DESCRIPTION
It seems that the `.env` is not read when running `bundle`, so `export BYOS_DATABASE=sqlite` must be run first.