### PR TITLE
doc: add BYOS_DATABASE to dotenv-sample

### DIFF
--- a/dotenv-sample
+++ b/dotenv-sample
@@ -1,2 +1,7 @@
+# the external, client-facing url
 BASE_URL="http://192.168.68.57:4567"
+
+# database can be 'sqlite' or 'pg'
+BYOS_DATABASE=sqlite
+
 APP_ENV="production"


### PR DESCRIPTION
`BYOS_DATABASE` should be explicitly documented as it must be set to use sqlite (which is probably the more suitable choice for most hobbyist tinkerers running this locally).