### PR TITLE
doc: use bundle exec for correct config with rake and ruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ with this project you can point a TRMNL (https://usetrmnl.com) device to your ow
 ```
 cp dotenv-sample .env # (and edit to set the appropriate variables)
 bundle # installs gems/libs
-rake db:setup # creates db + Devices table
+bundle exec rake db:setup # creates db + Devices table
 ruby app.rb # runs server, visit http://localhost:4567/devices/new
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ with this project you can point a TRMNL (https://usetrmnl.com) device to your ow
 cp dotenv-sample .env # (and edit to set the appropriate variables)
 bundle # installs gems/libs
 bundle exec rake db:setup # creates db + Devices table
-ruby app.rb # runs server, visit http://localhost:4567/devices/new
+bundle exec ruby app.rb # runs server, visit http://localhost:4567/devices/new
 ```
 
 **docker-based setup**


### PR DESCRIPTION
`bundle` installs `rake`, but running `rake` without `bundle exec` will run a different version of `rake` with a different config than the config used by `bundle` and the version of `rake` that is in the `Gemfile`.

Likewise, running `ruby` will run with the default system config, rather than with the project config.