### PR TITLE
fix: dotenv must come first

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -1,6 +1,7 @@
+require 'dotenv/load'
+
 require 'sinatra'
 require 'sinatra/activerecord'
-require 'dotenv/load'
 require 'debug'
 
 require_relative 'config/initializers/tailwind_form'


### PR DESCRIPTION
If `sinatra` loads before `dotenv` then the `.env` won't be read until after `sinatra` is configured.

When that happens, `production` is never set.

When that happens, all responses are always `Host not permitted` with this error in the logs:

```text
W, [2025-02-03T11:30:39.837391 #5940]  WARN -- : attack prevented by Rack::Protection::HostAuthorization
```

Necessary for #8 