### PR TITLE
Make sqlite the default database

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,6 @@ WORKDIR /app
 # Copy Gemfile and Gemfile.lock
 COPY Gemfile Gemfile.lock ./
 
-# Uncomment the next line to switch to sqlite
-#ENV BYOS_DATABASE=sqlite
-
 RUN bundle install 
 
 # Copy the rest of the application code

--- a/Gemfile
+++ b/Gemfile
@@ -18,12 +18,8 @@ gem 'puppeteer-ruby', '~> 0.45.6'
 # image processing
 gem 'mini_magick', '~> 4.12.0'
 
-byos_database = ENV.fetch('BYOS_DATABASE', 'pg')
-if byos_database == 'sqlite'
-  gem 'sqlite3'
-else
-  gem 'pg'
-end
+#db
+gem 'sqlite3'
 
 group :development, :test do
   gem 'debug'

--- a/README.md
+++ b/README.md
@@ -21,8 +21,6 @@ bundle exec ruby app.rb # runs server, visit http://localhost:4567/devices/new
 ```
 
 **docker-based setup**
-You may optionally edit the Dockerfile to enable sqlite.
-
 ```
 cp dotenv-sample .env # (and edit to set the appropriate variables)
 docker build -t trmnl_byos -f Dockerfile .

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,5 +1,3 @@
-<% byos_database = ENV.fetch('BYOS_DATABASE', 'pg') %>
-<% if byos_database == "sqlite" %>
 development:
   adapter: sqlite3
   encoding: unicode
@@ -9,23 +7,19 @@ production:
   adapter: sqlite3
   encoding: unicode
   database: db/trmnl_byos_sinatra.sqlite3
-<% else %>
-development:
-  adapter: postgresql
-  encoding: unicode
-  database: trmnl_byos_sinatra
-  pool: 2
-  # username: your_username
-  # password: your_password
 
-production:
-  adapter: postgresql
-  encoding: unicode
-  database: trmnl_byos_sinatra
-  pool: 2
-  # username: your_username
-  # password: your_password
-<% end %>
 test:
   adapter: sqlite3
   database: ":memory:"
+
+#if you want to use a database you already have
+# install the relevant gem, and then you  
+# can replace the production block above
+#eg postgres
+#production:
+#  adapter: postgresql
+#  encoding: unicode
+#  database: trmnl_byos_sinatra
+#  pool: 2
+#  username: your_username
+#  password: your_password


### PR DESCRIPTION
Based on our conversation on discord, use sqlite by default, but note how someone could use an alternate database if necessary.