### PR TITLE
added libyaml to fix sinatra-activerecord install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && \
     git \
     sqlite3 \
     pkg-config \
+    libyaml-dev \
     libpq-dev && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
While building the container, I couldn't complete the `bundle install`.
Making this change resolved the problem. I'm not familiar with ruby, but it looks like there might be conflicting configurations at some point:
```console
	--with-libyaml-source-dir
	--without-libyaml-source-dir
```


More context:
```console
<LOG TRUNCATED HERE>
Installing sinatra-activerecord 2.0.28
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /usr/local/bundle/gems/psych-5.2.1/ext/psych
/usr/local/bin/ruby extconf.rb
checking for pkg-config for yaml-0.1... not found
checking for yaml.h... no
yaml.h not found
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
<LOG TRUNCATED HERE>
	--with-libyaml-source-dir
	--without-libyaml-source-dir
	--with-yaml-0.1-dir
	--without-yaml-0.1-dir
	--with-yaml-0.1-include=${yaml-0.1-dir}/include
	--without-yaml-0.1-include
	--with-yaml-0.1-lib=${yaml-0.1-dir}/lib
	--without-yaml-0.1-lib
	--with-yaml-0.1-config
	--without-yaml-0.1-config
	--with-pkg-config
	--without-pkg-config
	--with-libyaml-dir
	--without-libyaml-dir
	--with-libyaml-include=${libyaml-dir}/include
	--without-libyaml-include
	--with-libyaml-lib=${libyaml-dir}/lib
	--without-libyaml-lib
<LOG TRUNCATED HERE>
An error occurred while installing psych (5.2.1), and Bundler cannot continue.

In Gemfile:
  debug was resolved to 1.9.2, which depends on
    irb was resolved to 1.14.2, which depends on
      rdoc was resolved to 6.8.1, which depends on
        psych
<LOG ENDED HERE>
```