### PR TITLE
Updated Docker scripts as Bash scripts

### DIFF
--- a/bin/docker/build
+++ b/bin/docker/build
@@ -1,16 +1,15 @@
-#! /usr/bin/env ruby
-# frozen_string_literal: true
+#! /usr/bin/env bash
 
-require "bundler/setup"
-Bundler.require :tools
+set -o nounset
+set -o errexit
+set -o pipefail
+IFS=$'\n\t'
 
-version = Bundler.root.join(".ruby-version").read.chop
+read -r version < ".ruby-version"
 
-system <<~COMMAND
-  docker buildx \
-         build \
-         --load \
-         --build-arg RUBY_VERSION=#{version} \
-         --tag byos_sinatra:latest \
-         #{Bundler.root}
-COMMAND
+docker buildx \
+       build \
+       --load \
+       --build-arg RUBY_VERSION="${version}" \
+       --tag byos_sinatra:latest \
+       "$(pwd)"

--- a/bin/docker/console
+++ b/bin/docker/console
@@ -1,15 +1,14 @@
-#! /usr/bin/env ruby
-# frozen_string_literal: true
+#! /usr/bin/env bash
 
-require "bundler/setup"
-Bundler.require :tools
+set -o nounset
+set -o errexit
+set -o pipefail
+IFS=$'\n\t'
 
-system <<~COMMAND
-  docker run \
-         --disable-content-trust \
-         --pull never \
-         --interactive \
-         --tty \
-         --rm byos_sinatra:latest \
-         bash
-COMMAND
+docker run \
+       --disable-content-trust \
+       --pull never \
+       --interactive \
+       --tty \
+       --rm byos_sinatra:latest \
+       bash


### PR DESCRIPTION
## Overview

Necessary to reduce the dependency on Ruby when building and using Docker. Ruby is still needed but when working at this level, you don't to be restricted to Ruby as of yet.
