### PR TITLE
Fixed GitHub Actions to include repository head ref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,12 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{github.head_ref}}
+
+      - name: Git Default Branch
+        run: git config set init.defaultBranch master
 
       - name: Ruby Setup
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
## Overview

Necessary for Git Lint to lint commit messages properly since GitHub Actions doesn't provide this by default. Git Lint needs to this determine which commits are on the feature branch.

This includes setting the default branch to `master` since Git Lint assumes `main` by default.

This will help provide consistent commits and, eventually, the generation of release notes which is important to communication changes to the community.
