### PR TITLE
allow for both production and development docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,9 +16,6 @@
 /.dockerignore
 /Dockerfile*
 
-# Environment
-/.env*
-
 # Git
 /.git/
 /.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,16 +12,19 @@ RUN <<STEPS
   && rm -rf /var/lib/apt/lists /var/cache/apt/archives
 STEPS
 
-ENV RACK_ENV=production
+ARG RACK_ENV="production"
+ARG BUNDLE_WITHOUT="development:quality:test:tools"
+ENV RACK_ENV="$RACK_ENV"
+ENV BUNDLE_WITHOUT="$BUNDLE_WITHOUT"
+
 ENV BUNDLE_DEPLOYMENT=1
 ENV BUNDLE_PATH=/usr/local/bundle
-ENV BUNDLE_WITHOUT="development:quality:test:tools"
 
 FROM base AS build
 
 RUN <<STEPS
   apt-get update -qq \
-  && apt-get install --no-install-recommends -y build-essential git pkg-config \
+  && apt-get install --no-install-recommends -y build-essential git pkg-config libyaml-dev \
   && rm -rf /var/lib/apt/lists /var/cache/apt/archives
 STEPS
 
@@ -43,9 +46,10 @@ RUN <<STEPS
 STEPS
 
 RUN groupadd --system --gid 1000 app && \
-    useradd app --uid 1000 --gid 1000 --create-home --shell /bin/bash && \
-    chown -R app:app log tmp
+  useradd app --uid 1000 --gid 1000 --create-home --shell /bin/bash && \
+  chown -R app:app log tmp
 
 USER 1000:1000
 
 ENTRYPOINT ["/app/bin/docker/entrypoint"]
+CMD [ "bundle", "exec", "ruby", "app.rb" ]

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,8 @@ gem "refinements", "~> 13.0"
 gem "sinatra-activerecord", "~> 2.0"
 gem "sqlite3", "~> 2.5"
 gem "zeitwerk", "~> 2.7"
+gem "dotenv", "~> 3.1"
+gem "ferrum", "~> 0.15"
 
 group :quality do
   gem "caliber", "~> 0.68"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -352,6 +352,7 @@ DEPENDENCIES
   dotenv (~> 3.1)
   ferrum (~> 0.15)
   forme (~> 2.6)
+  ferrum (~> 0.15)
   git-lint (~> 9.0)
   irb-kit (~> 1.1)
   json (~> 2.10)

--- a/bin/docker/build
+++ b/bin/docker/build
@@ -7,9 +7,33 @@ IFS=$'\n\t'
 
 read -r version < ".ruby-version"
 
+DOCKER_TAG="byos_sinatra:latest"
+APP_ENV="production"
+BUILD_ARGS=("--build-arg" "RUBY_VERSION=${version}")
+while [ -n "${1-}" ]; do
+       if [ ${1-""} == "-t" ]; then
+              shift
+              DOCKER_TAG="${1:-$DOCKER_TAG}"
+       fi
+       if [ ${1-""} == "--dev" ]; then
+              APP_ENV="development"
+              BUILD_ARGS+=("--build-arg" "RACK_ENV=development" "--build-arg" "BUNDLE_WITHOUT=''")
+       fi
+       shift
+done
+
+if [ ! -e .env ]; then
+       echo "No dotenv found. Using default environment"
+       cat <<DOTENV > .env
+APP_ENV=${APP_ENV}
+APP_HOST=0.0.0.0
+BASE_URL=http://localhost:4567
+DOTENV
+fi
+
 docker buildx \
        build \
        --load \
-       --build-arg RUBY_VERSION="${version}" \
-       --tag byos_sinatra:latest \
+       "${BUILD_ARGS[@]}" \
+       --tag $DOCKER_TAG \
        "$(pwd)"

--- a/bin/docker/build
+++ b/bin/docker/build
@@ -10,16 +10,23 @@ read -r version < ".ruby-version"
 DOCKER_TAG="byos_sinatra:latest"
 APP_ENV="production"
 BUILD_ARGS=("--build-arg" "RUBY_VERSION=${version}")
+
 while [ -n "${1-}" ]; do
-       if [ ${1-""} == "-t" ]; then
-              shift
-              DOCKER_TAG="${1:-$DOCKER_TAG}"
-       fi
-       if [ ${1-""} == "--dev" ]; then
-              APP_ENV="development"
-              BUILD_ARGS+=("--build-arg" "RACK_ENV=development" "--build-arg" "BUNDLE_WITHOUT=''")
-       fi
-       shift
+  case "${1-}" in
+    -t)
+      shift
+      DOCKER_TAG="${1:-$DOCKER_TAG}"
+      ;;
+    --dev)
+      APP_ENV="development"
+      BUILD_ARGS+=("--build-arg" "RACK_ENV=development" "--build-arg" "BUNDLE_WITHOUT=''")
+      ;;
+    *)
+      echo "Unknown argument \"$1\""
+      exit
+      ;;
+   esac
+   shift
 done
 
 if [ ! -e .env ]; then


### PR DESCRIPTION
## Overview
This continues a couple things from PR #38.

Fixes a two things about the docker build
* .env not being created by default or passed into docker build
* ensures a default command line is generated with CMD

It also now allows for --dev switch to docker build to build with dev and test dependencies, and a -t to easily specify a different tag, if desired.