### PR TITLE
Removed GitHub Actions default branch setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,6 @@ jobs:
           fetch-depth: 0
           ref: ${{github.head_ref}}
 
-      - name: Git Default Branch
-        run: git config set init.defaultBranch master
-
       - name: Ruby Setup
         uses: ruby/setup-ruby@v1
         with:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,7 +35,7 @@ GEM
       rubocop-performance (~> 1.24)
       rubocop-rake (~> 0.7)
       rubocop-rspec (~> 3.5)
-      rubocop-thread_safety (~> 0.7)
+      rubocop-thread_safety (~> 0.6)
     capybara (3.40.0)
       addressable
       matrix


### PR DESCRIPTION
## Overview

No longer necessary now that the default branch is `main`.
