### PR TITLE
Fixed dev container configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,1 +1,1 @@
-FROM bkuhlmann/alpine-ruby:latest
+FROM ruby:latest

--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -6,30 +6,12 @@ services:
       context: ..
       dockerfile: .devcontainer/Dockerfile
     volumes:
+      - app-db:/workspaces/byos_sinatra/db/sqlite
       - ../..:/workspaces:cached
     environment:
-      DATABASE_URL: postgres://postgres:postgres@postgres:5432/postgres
+      APP_URL: https://localhost:4443
+      DATABASE_URL: sqlite:///workspaces/byos_sinatra/db/sqlite/dev.sqlite
     command: sleep infinity
-    depends_on:
-      - postgres
-      - redis
-
-  postgres:
-    image: postgres:latest
-    restart: unless-stopped
-    volumes:
-      - postgres-data:/var/lib/postgresql/data
-    environment:
-      POSTGRES_USER: postgres
-      POSTGRES_DB: postgres
-      POSTGRES_PASSWORD: postgres
-
-  redis:
-    image: redis:latest
-    restart: unless-stopped
-    volumes:
-      - redis-data:/data
 
 volumes:
-  postgres-data:
-  redis-data:
+  app-db:

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,8 +8,9 @@
   },
   "containerEnv": {
     "CAPYBARA_SERVER_PORT": "45678",
-    "REDIS_URL": "redis://redis:6379/1"
   },
-  "forwardPorts": [2300, 3000, 5432, 6379],
+  "forwardPorts": [
+    4443
+  ],
   "postCreateCommand": "bin/setup"
 }


### PR DESCRIPTION
## Overview

We don't need PostgreSQL or Redis at the moment so these are safe to delete. This includes port forwarding and loading of SQLite database.

## Details

- This helps close out this [code review](https://github.com/usetrmnl/byos_sinatra/pull/47) by ensuring CI builds green and fixing the commit message so it's more descriptive.