### PR TITLE
Added automatic image rotation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,8 +45,11 @@ jobs:
             - vendor/bundle
 
       - run:
-          name: Database Setup
-          command: bin/rake db:prepare
+          name: Setup
+          command: |
+            mkdir -p public/images/generated
+            cp public/images/demo/rover.bmp public/images/generated/rover.bmp
+            bin/rake db:prepare
 
       - run:
           name: Build

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ COPY --from=build "${BUNDLE_PATH}" "${BUNDLE_PATH}"
 COPY --from=build /app /app
 
 RUN <<STEPS
+  mkdir -p /app/public/images/generated
   mkdir -p /app/log
   mkdir -p /app/tmp
 STEPS

--- a/README.adoc
+++ b/README.adoc
@@ -40,12 +40,16 @@ bin/setup
 
 == Usage
 
+To launch the server, run:
+
 [source,bash]
 ----
 bundle exec puma --config ./config/puma.rb
 ----
 
 💡 Install link:https://github.com/DarthSim/overmind[Overmind] and run `overmind start` to run with full access to all processes (including remote debugging).
+
+To use the app, open `http://localhost:4567` in your browser to view the app and manage your device(s).
 
 == Development
 
@@ -88,6 +92,80 @@ Images::Creator.new.call "<p>Test.</p>", Pathname.pwd.join("%<name>s.bmp")
 #<Pathname:byos_sinatra/c8e41972-c7bb-47d8-b927-ddcf50d20367.bmp>
 ----
 
+When creating images, you might find this HTML template valuable as a starting point as this let's you use the full capabilities of HTML to create new images for your device.
+
+.HTML Template
+[%collapsible]
+====
+[source,html]
+----
+<!DOCTYPE html>
+
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no">
+
+    <title>Demo</title>
+
+    <meta charset="utf-8">
+
+    <style type="text/css">
+      * {
+        margin: 0;
+      }
+    </style>
+
+    <script type="text/javascript">
+    </script>
+  </head>
+
+  <body>
+    <img src="uri/to/image" alt="Image"/>
+  </body>
+</html>
+----
+====
+
+Use of `margin` zero is important to prevent default browser styles from creating borders around your image which will show up when rendered on your device. Otherwise, you have full capabilities to render any kind of page you want using whatever HTML you like. Anything is possible because `Images::Creator` is designed to screenshot your rendered HTML as a 800x480 image to render on your device. If you put all this together, that means you can do this in the console:
+
+.Console Image Generation
+[%collapsible]
+====
+[source,ruby]
+----
+creator = Images::Creator.new
+
+creator.call(<<~CONTENT, Pathname("public/images/generated/"%<name>s.bmp""))
+  <!DOCTYPE html>
+
+  <html lang="en">
+    <head>
+      <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no">
+
+      <title>Demo</title>
+
+      <meta charset="utf-8">
+
+      <style type="text/css">
+        * {
+          margin: 0;
+        }
+      </style>
+
+      <script type="text/javascript">
+      </script>
+    </head>
+
+    <body>
+      <h1>Hello, World!</h1>
+    </body>
+  </html>
+CONTENT
+----
+====
+
+The above will create a new image in the `public/images/generated` folder of this application which will eventually render on your device. 🎉
+
 To build a {docker_link} image, run:
 
 [source,bash]
@@ -111,7 +189,7 @@ To test, run:
 bin/rake
 ----
 
-== Deployement
+== Deployment
 
 *Local*
 

--- a/app.rb
+++ b/app.rb
@@ -106,12 +106,12 @@ module TRMNL
 
       if device
         encryption = :base_64 if (env["HTTP_BASE64"] || params[:base64]) == "true"
-        screen = Images::Fetcher.new(encryption:).call Pathname.pwd.join("public/images/generated")
+        image = Images::Rotator.new.call(Pathname.pwd.join("public/images/generated"), encryption:)
 
         # FIX: On Core, a 202 status loops device back to /api/setup unless User is connected.
         payload.merge! status: 0,
-                       image_url: screen[:image_url],
-                       filename: screen[:filename],
+                       image_url: image[:image_url],
+                       filename: image[:filename],
                        refresh_rate: device.refresh_interval,
                        reset_firmware: false,
                        update_firmware: false,

--- a/lib/images/fetcher.rb
+++ b/lib/images/fetcher.rb
@@ -10,19 +10,20 @@ module Images
 
     ALLOWED_ENCRYPTIONS = %i[base_64].freeze
 
-    def initialize encryption: nil, allowed_encryptions: ALLOWED_ENCRYPTIONS, environment: ENV
-      @encryption = encryption
+    def initialize allowed_encryptions: ALLOWED_ENCRYPTIONS, environment: ENV
       @allowed_encryptions = allowed_encryptions
       @environment = environment
     end
 
-    def call(root_path = Pathname.pwd) = last_generated_image(root_path) || default_image
+    def call root_path = Pathname.pwd, encryption: nil
+      last_generated_image(root_path, encryption) || default_image
+    end
 
     private
 
-    attr_reader :encryption, :allowed_encryptions, :environment
+    attr_reader :allowed_encryptions, :environment
 
-    def last_generated_image root_path
+    def last_generated_image root_path, encryption
       image_path = root_path.files("*.bmp").max_by(&:ctime)
 
       return unless image_path

--- a/lib/images/rotator.rb
+++ b/lib/images/rotator.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Images
+  # Rotates and fetches images for rendering on a device.
+  class Rotator
+    def initialize toucher: Toucher, fetcher: Fetcher.new
+      @toucher = toucher
+      @fetcher = fetcher
+    end
+
+    def call root, encryption: nil
+      toucher.call root
+      fetcher.call root, encryption:
+    end
+
+    private
+
+    attr_reader :toucher, :fetcher
+  end
+end

--- a/lib/images/toucher.rb
+++ b/lib/images/toucher.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "refinements/pathname"
+
+# Touches the oldest file to make it the latest file.
+module Images
+  using Refinements::Pathname
+
+  Toucher = -> root { Pathname(root).files.min_by(&:ctime).touch }
+end

--- a/spec/lib/images/fetcher_spec.rb
+++ b/spec/lib/images/fetcher_spec.rb
@@ -32,24 +32,20 @@ RSpec.describe Images::Fetcher do
     end
 
     it "answers generated image with encryption" do
-      fetcher = described_class.new(encryption: :base_64, environment:)
-
       path = temp_dir.join("public/images/generated").mkpath.join("test.bmp")
       fixture_path.copy path
 
-      expect(fetcher.call(path.parent)).to match(
+      expect(fetcher.call(path.parent, encryption: :base_64)).to match(
         filename: "test.bmp",
         image_url: %r(data:image/bmp;base64,.+)
       )
     end
 
     it "answers generated image without encryption when given invalid encryption" do
-      fetcher = described_class.new(encryption: :bogus, environment:)
-
       path = temp_dir.join("public/images/generated").mkpath.join("test.bmp")
       fixture_path.copy path
 
-      expect(fetcher.call(path.parent)).to eq(
+      expect(fetcher.call(path.parent, encryption: :bogus)).to eq(
         filename: "test.bmp",
         image_url: "https://test.io/images/generated/test.bmp"
       )

--- a/spec/lib/images/rotator_spec.rb
+++ b/spec/lib/images/rotator_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Images::Rotator do
+  using Refinements::Pathname
+
+  subject(:rotator) { described_class.new fetcher: Images::Fetcher.new(environment:) }
+
+  include_context "with temporary directory"
+
+  let(:environment) { {"APP_URL" => "https://test.io"} }
+
+  describe "#call" do
+    it "answers oldest image as newest image" do
+      temp_dir.join("one.bmp").touch
+      temp_dir.join("two.bmp").touch
+
+      expect(rotator.call(temp_dir)).to eq(
+        filename: "one.bmp",
+        image_url: "https://test.io/images/generated/one.bmp"
+      )
+    end
+
+    it "answers oldest image as newest image with encryption" do
+      temp_dir.join("one.bmp").touch
+      temp_dir.join("two.bmp").touch
+
+      expect(rotator.call(temp_dir, encryption: :base_64)).to eq(
+        filename: "one.bmp",
+        image_url: "data:image/bmp;base64,"
+      )
+    end
+  end
+end

--- a/spec/lib/images/toucher_spec.rb
+++ b/spec/lib/images/toucher_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Images::Toucher do
+  using Refinements::Pathname
+
+  subject(:toucher) { described_class }
+
+  include_context "with temporary directory"
+
+  describe "#call" do
+    let(:one) { temp_dir.join "one.png" }
+    let(:two) { temp_dir.join "two.png" }
+    let(:three) { temp_dir.join "three.png" }
+    let(:all) { [one, two, three] }
+
+    it "answers second file created as latest file" do
+      skip "Doesn't work on CI." if ENV["CI"]
+
+      all.each(&:touch)
+      toucher.call temp_dir
+
+      expect(all.sort_by(&:ctime)).to eq([two, three, one])
+    end
+
+    it "answers last file created as latest file" do
+      skip "Doesn't work on CI." if ENV["CI"]
+
+      all.each(&:touch)
+      toucher.call temp_dir
+      toucher.call temp_dir
+
+      expect(all.sort_by(&:ctime)).to eq([three, one, two])
+    end
+  end
+end


### PR DESCRIPTION
## Overview

This builds upon image creation already supported via the `Images::Creator` class (see documentation for details) by ensuring images are rotated when running the server locally. In a sense, this behaves like a lightweight playlist which improves the out-of-the-box experience by seeing different images rotated upon each new `/api/display` request.

## Details

- This compliments [Issue 33](https://github.com/usetrmnl/byos_sinatra/issues/33) where you'll soon be able to generate images via the API.
- See commits for details.