### PR TITLE
Fixed screensaver viewport scaling

### DIFF
--- a/lib/images/screensaver.rb
+++ b/lib/images/screensaver.rb
@@ -12,17 +12,18 @@ module Images
         "hide-scrollbar" => nil,
         "no-sandbox" => nil
       },
-      js_errors: true,
-      window_size: [800, 480]
+      js_errors: true
     }.freeze
+
+    VIEWPORT = {width: 800, height: 480, scale_factor: 1}.freeze
 
     def initialize settings: SETTINGS, browser: Ferrum::Browser
       @settings = settings
       @browser = browser
     end
 
-    def call content, path
-      save content, path
+    def call content, path, viewport: VIEWPORT
+      save content, path, viewport
       path
     end
 
@@ -30,17 +31,15 @@ module Images
 
     attr_reader :settings, :browser
 
-    def save content, path
+    def save content, path, viewport
       browser.new(settings).then do |instance|
         instance.create_page
-        instance.resize(**dimensions)
+        instance.set_viewport(**viewport)
         instance.execute "document.documentElement.innerHTML = `#{content}`;"
         instance.network.wait_for_idle
         instance.screenshot path: path.to_s
         instance.quit
       end
     end
-
-    def dimensions = settings.fetch(:window_size).then { |width, height| {width:, height:} }
   end
 end

--- a/spec/lib/images/creator_spec.rb
+++ b/spec/lib/images/creator_spec.rb
@@ -32,9 +32,10 @@ RSpec.describe Images::Creator do
       image = MiniMagick::Image.open path
 
       expect(image).to have_attributes(
-        dimensions: [800, 480],
-        exif: {},
+        width: 800,
+        height: 480,
         type: "BMP3",
+        exif: {},
         data: hash_including("depth" => 1, "baseDepth" => 1)
       )
     end

--- a/spec/lib/images/screensaver_spec.rb
+++ b/spec/lib/images/screensaver_spec.rb
@@ -29,7 +29,9 @@ RSpec.describe Images::Screensaver do
 
     it "creates screenshot" do
       screensaver.call content, path
-      expect(path.exist?).to be(true)
+      image = MiniMagick::Image.open path
+
+      expect(image).to have_attributes(width: 800, height: 480, type: "JPEG", exif: {})
     end
 
     it "answers image path" do


### PR DESCRIPTION
## Overview

Necessary to ensure images don't end up larger than the desired viewport by setting the `scale_factor` to `1` to control the [devicePixelRatio](https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio).

The window dimensions have been extracted from the browser settings in favor keeping keep all of this information (including scale factor) as a view port setting which can be alterted at runtime if desired.

## Details

- Resolves Issue #61.